### PR TITLE
Add bundle size stats

### DIFF
--- a/src/WebpackBuildStatsPlugin.ts
+++ b/src/WebpackBuildStatsPlugin.ts
@@ -4,11 +4,29 @@ import type { Compiler, Stats, StatsCompilation } from 'webpack';
 
 export class WebpackBuildStatsPlugin {
   private readonly customIdentifier: string | undefined;
+  private bundleFiles: Record<string, number> = {};
+  private bundleSize: number = 0;
+
   constructor(customIdentifier: string | undefined = process.env.npm_lifecycle_event) {
     this.customIdentifier = customIdentifier;
   }
 
   apply(compiler: Compiler) {
+    compiler.hooks.emit.tapAsync('AgodaBuildStatsPlugin', (compilation, callback) => {
+      this.bundleSize = 0;
+      this.bundleFiles = {};
+
+      for (const assetName in compilation.assets) {
+        if (compilation.assets.hasOwnProperty(assetName)) {
+          const asset = compilation.assets[assetName];
+          this.bundleFiles[assetName] = asset.size();
+          this.bundleSize += asset.size();
+        }
+      }
+
+      callback();
+    });
+
     compiler.hooks.done.tap('AgodaBuildStatsPlugin', async (stats: Stats) => {
       const jsonStats: StatsCompilation = stats.toJson();
 
@@ -19,6 +37,8 @@ export class WebpackBuildStatsPlugin {
         webpackVersion: jsonStats.version ?? null,
         nbrOfCachedModules: jsonStats.modules?.filter((m) => m.cached).length ?? 0,
         nbrOfRebuiltModules: jsonStats.modules?.filter((m) => m.built).length ?? 0,
+        bundleFiles: this.bundleFiles ?? {},
+        bundleSize: this.bundleSize ?? 0,
       };
 
       sendBuildData(buildStats);

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,9 +27,13 @@ export interface WebpackBuildData extends CommonMetadata {
   compilationHash: string | null;
   nbrOfCachedModules: number;
   nbrOfRebuiltModules: number;
+  bundleFiles: Record<string, number>;
+  bundleSize: number;
 }
 
 export interface ViteBuildData extends CommonMetadata {
   type: 'vite';
   viteVersion: string | null;
+  bundleFiles: Record<string, number>;
+  bundleSize: number;
 }

--- a/src/viteBuildStatsPlugin.ts
+++ b/src/viteBuildStatsPlugin.ts
@@ -1,6 +1,8 @@
 import type { ViteBuildData } from './types';
 import { type Plugin } from 'vite';
 import { getCommonMetadata, sendBuildData } from './common';
+import { promises as fs } from 'fs';
+import path from 'path';
 
 export function viteBuildStatsPlugin(
   customIdentifier: string | undefined = process.env.npm_lifecycle_event,
@@ -8,6 +10,8 @@ export function viteBuildStatsPlugin(
   let buildStart: number;
   let buildEnd: number;
   let rollupVersion: string | undefined = undefined;
+  let bundleFiles: Record<string, number> = {};
+  let bundleSize: number = 0;
 
   return {
     name: 'vite-plugin-agoda-build-reporter',
@@ -18,11 +22,25 @@ export function viteBuildStatsPlugin(
     buildEnd: function () {
       buildEnd = Date.now();
     },
+    writeBundle: async function (options, bundle) {
+      for (const [fileName, assetInfo] of Object.entries(bundle)) {
+        const filePath = path.join(options.dir || '', fileName);
+        try {
+          const stats = await fs.stat(filePath);
+          bundleFiles[fileName] = stats.size;
+          bundleSize += stats.size;
+        } catch (err) {
+          console.error(`Error reading file size for ${fileName}:`, err);
+        }
+      }
+    },
     closeBundle: async function () {
       const buildStats: ViteBuildData = {
         ...getCommonMetadata(buildEnd - buildStart, customIdentifier),
         type: 'vite',
         viteVersion: rollupVersion ?? null,
+        bundleFiles,
+        bundleSize,
       };
 
       sendBuildData(buildStats);

--- a/tests/viteBuildStatsPlugin.spec.ts
+++ b/tests/viteBuildStatsPlugin.spec.ts
@@ -1,22 +1,36 @@
 import type { CommonMetadata, ViteBuildData } from '../src/types';
 import { viteBuildStatsPlugin } from '../src/viteBuildStatsPlugin';
 import { getCommonMetadata, sendBuildData } from '../src/common';
+import { BigIntStats, PathLike, Stats, promises as fs } from 'fs';
+import path from 'path';
 
 jest.mock('../src/common', () => ({
   getCommonMetadata: jest.fn(),
   sendBuildData: jest.fn(),
 }));
 
+jest.mock('fs', () => ({
+  promises: {
+    stat: jest.fn(),
+  },
+}));
+
 const mockedGetCommonMetadata = getCommonMetadata as jest.MockedFunction<
   typeof getCommonMetadata
 >;
 const mockedSendBuildData = sendBuildData as jest.MockedFunction<typeof sendBuildData>;
+const mockedFsStat = fs.stat as jest.MockedFunction<typeof fs.stat>;
 
 describe('viteBuildStatsPlugin', () => {
   const expected: ViteBuildData = {
     type: 'vite',
     viteVersion: '1.2.3',
-  } as ViteBuildData;
+    bundleFiles: {
+      'file1.js': 1000,
+      'file2.js': 2000,
+    },
+    bundleSize: 3000,
+  } as unknown as ViteBuildData;
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -32,9 +46,21 @@ describe('viteBuildStatsPlugin', () => {
     mockedGetCommonMetadata.mockReturnValue({} as CommonMetadata);
     mockedSendBuildData.mockReturnValue(Promise.resolve());
 
+    // mock fs.stat
+    mockedFsStat.mockImplementation((path: PathLike) => {
+      if (path.toString().endsWith('file1.js')) {
+        return Promise.resolve({ size: 1000 } as Stats);
+      } else if (path.toString().endsWith('file2.js')) {
+        return Promise.resolve({ size: 2000 } as Stats);
+      } else {
+        return Promise.reject(new Error('File not found'));
+      }
+    });
+
     const plugin = viteBuildStatsPlugin('my custom identifier');
     (plugin.buildStart as () => void).bind({ meta: { rollupVersion: '1.2.3' } })();
     (plugin.buildEnd as () => void)();
+    await (plugin.writeBundle as any)({ dir: 'dist' }, { 'file1.js': {}, 'file2.js': {} });
     await (plugin.closeBundle as () => Promise<void>)();
 
     expect(mockedGetCommonMetadata).toBeCalledWith(100, 'my custom identifier');
@@ -58,9 +84,21 @@ describe('viteBuildStatsPlugin', () => {
       },
     } as unknown as typeof process;
 
+    // mock fs.stat
+    mockedFsStat.mockImplementation((path: PathLike) => {
+      if (path.toString().endsWith('file1.js')) {
+        return Promise.resolve({ size: 1000 } as Stats);
+      } else if (path.toString().endsWith('file2.js')) {
+        return Promise.resolve({ size: 2000 } as Stats);
+      } else {
+        return Promise.reject(new Error('File not found'));
+      }
+    });
+
     const plugin = viteBuildStatsPlugin();
     (plugin.buildStart as () => void).bind({ meta: { rollupVersion: '1.2.3' } })();
     (plugin.buildEnd as () => void)();
+    await (plugin.writeBundle as any)({ dir: 'dist' }, { 'file1.js': {}, 'file2.js': {} });
     await (plugin.closeBundle as () => Promise<void>)();
 
     expect(mockedGetCommonMetadata).toBeCalledWith(100, 'default_value');


### PR DESCRIPTION
# Add Bundle Size

## ViteBuildStatsPlugin

- Added `bundleFiles` and `bundleSizes` in `viteBuildStatsPlugin`.
- `bundleFiles` is a record of all files generated from the build process, stored as:
  - `key`: `file name`
  - `value`: `file size in bytes`
- `bundleSizes` is the total size of all files contained in `bundleFiles`.

## WebpackBuildStatsPlugin

- Added `bundleFiles` and `bundleSizes` in `WebpackBuildStatsPlugin`.
- `bundleFiles` is a record of all files generated from the build process, stored as:
  - `key`: `file name`
  - `value`: `file size in bytes`
- `bundleSizes` is the total size of all files contained in `bundleFiles`.

## Result

| Bundle  | Result from devfeedback                                                                                    | Result from bundle analyzer                                                                                |
| ------- | ---------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
| Vite    | ![image](https://github.com/agoda-com/devfeedback-js/assets/80260773/d660c2ce-6919-4eef-9112-6983d89c86dc) | ![image](https://github.com/agoda-com/devfeedback-js/assets/80260773/e65730fa-797d-49e7-9a60-b905ace86cb0) |
| Webpack | ![image](https://github.com/agoda-com/devfeedback-js/assets/80260773/f43d9cc2-38d6-488b-b974-cdb6ef972126) | ![image](https://github.com/agoda-com/devfeedback-js/assets/80260773/c6749be7-df74-4460-bd93-11fb90610013) |

## Notes

- `bundleFiles` will contain all files such as `*.js`, `*.LICENSE.txt`, `.css`, `.svg`.
- File sizes in `Vite` may not be the same as the output from the analyzer because the analyzer gets bundle info from Rollup, but I get it from the actual file in disk with `fs`.