### PR TITLE
Optimize plugin

### DIFF
--- a/src/WebpackBuildStatsPlugin.ts
+++ b/src/WebpackBuildStatsPlugin.ts
@@ -9,7 +9,7 @@ export class WebpackBuildStatsPlugin {
   }
 
   apply(compiler: Compiler) {
-    compiler.hooks.done.tapAsync('AgodaBuildStatsPlugin', async (stats: Stats, callback) => {
+    compiler.hooks.done.tapPromise('AgodaBuildStatsPlugin', async (stats: Stats) => {
       let nbrOfCachedModules = 0, nbrOfRebuiltModules = 0;
       // https://github.com/webpack/webpack/blob/f4092a60598a73447687fa6e6375bb4786bfcbe3/lib/stats/DefaultStatsFactoryPlugin.js#L1142
       const compilation = stats.compilation;
@@ -30,7 +30,6 @@ export class WebpackBuildStatsPlugin {
       };
 
       await sendBuildData(buildStats);
-      callback();
     });
   }
 }

--- a/src/WebpackBuildStatsPlugin.ts
+++ b/src/WebpackBuildStatsPlugin.ts
@@ -9,7 +9,7 @@ export class WebpackBuildStatsPlugin {
   }
 
   apply(compiler: Compiler) {
-    compiler.hooks.done.tap('AgodaBuildStatsPlugin', async (stats: Stats) => {
+    compiler.hooks.done.tapPromise('AgodaBuildStatsPlugin', async (stats: Stats) => {
       let nbrOfCachedModules = 0, nbrOfRebuiltModules = 0;
       // https://github.com/webpack/webpack/blob/f4092a60598a73447687fa6e6375bb4786bfcbe3/lib/stats/DefaultStatsFactoryPlugin.js#L1142
       const compilation = stats.compilation;
@@ -29,7 +29,7 @@ export class WebpackBuildStatsPlugin {
         nbrOfRebuiltModules,
       };
 
-      sendBuildData(buildStats);
+      await sendBuildData(buildStats);
     });
   }
 }

--- a/src/WebpackBuildStatsPlugin.ts
+++ b/src/WebpackBuildStatsPlugin.ts
@@ -10,15 +10,23 @@ export class WebpackBuildStatsPlugin {
 
   apply(compiler: Compiler) {
     compiler.hooks.done.tap('AgodaBuildStatsPlugin', async (stats: Stats) => {
-      const jsonStats: StatsCompilation = stats.toJson();
-
+      let nbrOfCachedModules = 0, nbrOfRebuiltModules = 0;
+      // https://github.com/webpack/webpack/blob/f4092a60598a73447687fa6e6375bb4786bfcbe3/lib/stats/DefaultStatsFactoryPlugin.js#L1142
+      const compilation = stats.compilation;
+      for (const module of compilation.modules) {
+        if (!compilation.builtModules.has(module) && !compilation.codeGeneratedModules.has(module)) {
+          nbrOfCachedModules += 1;
+        } else {
+          nbrOfRebuiltModules += 1;
+        }
+      }
       const buildStats: WebpackBuildData = {
-        ...getCommonMetadata(jsonStats.time ?? -1, this.customIdentifier),
+        ...getCommonMetadata(stats.endTime - stats.startTime ?? -1, this.customIdentifier),
         type: 'webpack',
-        compilationHash: jsonStats.hash ?? null,
-        webpackVersion: jsonStats.version ?? null,
-        nbrOfCachedModules: jsonStats.modules?.filter((m) => m.cached).length ?? 0,
-        nbrOfRebuiltModules: jsonStats.modules?.filter((m) => m.built).length ?? 0,
+        compilationHash: stats.hash ?? null,
+        webpackVersion: compiler.webpack.version ?? null,
+        nbrOfCachedModules,
+        nbrOfRebuiltModules,
       };
 
       sendBuildData(buildStats);

--- a/src/WebpackBuildStatsPlugin.ts
+++ b/src/WebpackBuildStatsPlugin.ts
@@ -9,7 +9,7 @@ export class WebpackBuildStatsPlugin {
   }
 
   apply(compiler: Compiler) {
-    compiler.hooks.done.tapPromise('AgodaBuildStatsPlugin', async (stats: Stats) => {
+    compiler.hooks.done.tapAsync('AgodaBuildStatsPlugin', async (stats: Stats, callback) => {
       let nbrOfCachedModules = 0, nbrOfRebuiltModules = 0;
       // https://github.com/webpack/webpack/blob/f4092a60598a73447687fa6e6375bb4786bfcbe3/lib/stats/DefaultStatsFactoryPlugin.js#L1142
       const compilation = stats.compilation;
@@ -30,6 +30,7 @@ export class WebpackBuildStatsPlugin {
       };
 
       await sendBuildData(buildStats);
+      callback();
     });
   }
 }

--- a/tests/WebpackBuildStatsPlugin.spec.ts
+++ b/tests/WebpackBuildStatsPlugin.spec.ts
@@ -13,10 +13,19 @@ const mockedGetCommonMetadata = getCommonMetadata as jest.MockedFunction<
 >;
 const mockedSendBuildData = sendBuildData as jest.MockedFunction<typeof sendBuildData>;
 
+const compilation = {
+  modules: new Set([1, 2, 3]),
+  builtModules: new Set([1]),
+  codeGeneratedModules: new Set([2]),
+};
 const mockedCompiler = {
+  webpack: {
+    version: '5.51.1',
+  },
+  compilation,
   hooks: {
     done: {
-      tap: jest.fn(),
+      tapPromise: jest.fn(),
     },
   },
 };
@@ -27,7 +36,7 @@ describe('WebpackBuildStatsPlugin', () => {
     webpackVersion: '5.51.1',
     compilationHash: 'blahblahblacksheep',
     nbrOfCachedModules: 1,
-    nbrOfRebuiltModules: 1,
+    nbrOfRebuiltModules: 2,
   } as WebpackBuildData;
 
   beforeEach(() => {
@@ -41,6 +50,10 @@ describe('WebpackBuildStatsPlugin', () => {
 
     // mock stats
     const mockedStats = {
+      compilation,
+      startTime: 1000,
+      endTime: 1123,
+      hash: 'blahblahblacksheep',
       toJson: jest.fn().mockReturnValue({
         time: 123,
         hash: 'blahblahblacksheep',
@@ -55,7 +68,7 @@ describe('WebpackBuildStatsPlugin', () => {
     const plugin = new WebpackBuildStatsPlugin('my custom identifier');
     plugin.apply(mockedCompiler as unknown as Compiler);
 
-    const callback = mockedCompiler.hooks.done.tap.mock.calls[0][1];
+    const callback = mockedCompiler.hooks.done.tapPromise.mock.calls[0][1];
     await callback(mockedStats as unknown as import('webpack').Stats);
 
     expect(mockedGetCommonMetadata).toBeCalledWith(123, 'my custom identifier');
@@ -65,6 +78,10 @@ describe('WebpackBuildStatsPlugin', () => {
   it('should use process.env.npm_lifecycle_event as default custom identifier', async () => {
     // mock stats
     const mockedStats = {
+      compilation,
+      startTime: 1000,
+      endTime: 1123,
+      hash: 'blahblahblacksheep',
       toJson: jest.fn().mockReturnValue({
         time: 123,
         hash: 'blahblahblacksheep',
@@ -86,7 +103,7 @@ describe('WebpackBuildStatsPlugin', () => {
     const plugin = new WebpackBuildStatsPlugin();
     plugin.apply(mockedCompiler as unknown as Compiler);
 
-    const callback = mockedCompiler.hooks.done.tap.mock.calls[0][1];
+    const callback = mockedCompiler.hooks.done.tapPromise.mock.calls[0][1];
     await callback(mockedStats as unknown as import('webpack').Stats);
 
     expect(mockedGetCommonMetadata).toBeCalledWith(123, 'default_value');


### PR DESCRIPTION
Remove the generation of stats.json
Copy the code from getting the cached and built modules from the stats json generation logic
Actually await on sending the metric, and use tapPromise