### PR TITLE
Optimize webpack plugin

### DIFF
--- a/packages/webpack-plugin/src/lib/webpack-build-stats-plugin.spec.ts
+++ b/packages/webpack-plugin/src/lib/webpack-build-stats-plugin.spec.ts
@@ -26,7 +26,7 @@ const createMockCompiler = () => {
         tap: vi.fn(),
       },
       done: {
-        tap: vi.fn(),
+        tapPromise: vi.fn(),
       },
       compilation: {
         tap: vi.fn(),
@@ -63,7 +63,7 @@ describe('WebpackBuildStatsPlugin', () => {
       'WebpackBuildStatsPlugin',
       expect.any(Function),
     );
-    expect(mockedCompiler.hooks.done.tap).toHaveBeenCalledWith(
+    expect(mockedCompiler.hooks.done.tapPromise).toHaveBeenCalledWith(
       'WebpackBuildStatsPlugin',
       expect.any(Function),
     );
@@ -97,7 +97,7 @@ describe('WebpackBuildStatsPlugin', () => {
 
     // Act
     // Retrieve the callback the plugin registered with the "done" hook
-    const doneHookCallback = mockedCompiler.hooks.done.tap.mock.calls[0][1];
+    const doneHookCallback = mockedCompiler.hooks.done.tapPromise.mock.calls[0][1];
     // Simulate a completed build
     await doneHookCallback(mockedStats);
 
@@ -141,7 +141,7 @@ describe('WebpackBuildStatsPlugin', () => {
     mockedSendBuildData.mockResolvedValue(undefined);
 
     // Act
-    const doneHookCallback = mockedCompiler.hooks.done.tap.mock.calls[0][1];
+    const doneHookCallback = mockedCompiler.hooks.done.tapPromise.mock.calls[0][1];
     await doneHookCallback(mockedStats);
 
     // Assert

--- a/packages/webpack-plugin/src/lib/webpack-build-stats-plugin.ts
+++ b/packages/webpack-plugin/src/lib/webpack-build-stats-plugin.ts
@@ -67,7 +67,7 @@ export class WebpackBuildStatsPlugin {
     /**
      * 3) done => record "compileDone" and then send build stats with devFeedback
      */
-    compiler.hooks.done.tap('WebpackBuildStatsPlugin', async (stats: Stats) => {
+    compiler.hooks.done.tapPromise('WebpackBuildStatsPlugin', async (stats: Stats) => {
       this.recordEvent({ type: 'compileDone' });
 
       // Original build-stats logic

--- a/packages/webpack-plugin/src/lib/webpack-build-stats-plugin.ts
+++ b/packages/webpack-plugin/src/lib/webpack-build-stats-plugin.ts
@@ -71,7 +71,7 @@ export class WebpackBuildStatsPlugin {
       this.recordEvent({ type: 'compileDone' });
 
       // Original build-stats logic
-      const jsonStats: StatsCompilation = stats.toJson();
+      const jsonStats: StatsCompilation = stats.toJson({ preset: 'none', timings: true, hash: true, version: true, modules: true });
 
       const buildStats: WebpackBuildData = {
         ...getCommonMetadata(jsonStats.time ?? -1, this.customIdentifier),

--- a/packages/webpack-plugin/src/lib/webpack-build-stats-plugin.ts
+++ b/packages/webpack-plugin/src/lib/webpack-build-stats-plugin.ts
@@ -71,7 +71,13 @@ export class WebpackBuildStatsPlugin {
       this.recordEvent({ type: 'compileDone' });
 
       // Original build-stats logic
-      const jsonStats: StatsCompilation = stats.toJson({ preset: 'none', timings: true, hash: true, version: true, modules: true });
+      const jsonStats: StatsCompilation = stats.toJson({
+        preset: 'none',
+        timings: true,
+        hash: true,
+        version: true,
+        modules: true,
+      });
 
       const buildStats: WebpackBuildData = {
         ...getCommonMetadata(jsonStats.time ?? -1, this.customIdentifier),


### PR DESCRIPTION
- Use a minimal set of information for stats generation
- Use tapPromise to correctly make sure other hooks can run, and make sure this hook runs to completion