### PR TITLE
Add logs, change response codes, change type for hmr vite

### DIFF
--- a/packages/common/src/lib/common.ts
+++ b/packages/common/src/lib/common.ts
@@ -102,5 +102,7 @@ export const sendBuildData = async (
     return;
   }
 
-  console.log(`Your build stats has successfully been sent.`);
+  console.log(
+    `Your build stats has successfully been sent to ${endpoint} for ${buildStats.type}.`,
+  );
 };

--- a/packages/common/src/lib/types.ts
+++ b/packages/common/src/lib/types.ts
@@ -49,7 +49,7 @@ export interface ViteBundleStats {
 }
 
 export interface ViteBuildData extends CommonMetadata {
-  type: 'vite';
+  type: string;
   viteVersion: string | null;
   bundleStats?: ViteBundleStats;
   file: string | null;

--- a/packages/vite-plugin/src/lib/vite-build-stats-plugin.ts
+++ b/packages/vite-plugin/src/lib/vite-build-stats-plugin.ts
@@ -96,7 +96,7 @@ export function viteBuildStatsPlugin(
 
                 const metricsData: ViteBuildData = {
                   ...getCommonMetadata(totalTime, customIdentifier),
-                  type: 'vite',
+                  type: 'vite-hmr',
                   viteVersion: rollupVersion ?? null,
                   bundleStats: {
                     bootstrapChunkSizeBytes: undefined,
@@ -111,7 +111,7 @@ export function viteBuildStatsPlugin(
                 res.writeHead(200, { 'Content-Type': 'application/json' });
                 res.end(JSON.stringify({ success: true }));
               } else {
-                res.writeHead(200, { 'Content-Type': 'application/json' });
+                res.writeHead(404, { 'Content-Type': 'application/json' });
                 res.end(
                   JSON.stringify({
                     success: false,
@@ -123,7 +123,7 @@ export function viteBuildStatsPlugin(
               }
             } catch (err) {
               console.error('[vite-timing] Error processing timing data:', err);
-              res.writeHead(200, { 'Content-Type': 'application/json' });
+              res.writeHead(500, { 'Content-Type': 'application/json' });
               res.end(
                 JSON.stringify({
                   success: false,


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0faf02c4-1f18-401a-9188-ab4c03dc5f6b)

Getting empty responses from HMR events, unable to tell why, adding more logs, but also noticed the "type" for build and HMR events was the same, so fixing that too